### PR TITLE
fix(.happo.js, README): update example next config

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 const { RemoteBrowserTarget } = require('happo.io');
 
+const { findPagesDir } = require('next/dist/lib/find-pages-dir');
 const nextWebpackConfig = require('next/dist/build/webpack-config').default;
 const nextConfig = require('./next.config');
 
@@ -19,12 +20,16 @@ module.exports = {
       config: {
         devIndicators: {},
         distDir: happoTmpDir,
+        env: {},
         experimental: { plugins: [] },
         future: {},
-        env: {},
+        pageExtensions: [],
+        sassOptions: {},
         ...nextConfig,
       },
       entrypoints: {},
+      pagesDir: findPagesDir(process.cwd()),
+      rewrites: [],
     });
     config.plugins = base.plugins;
     config.resolve = base.resolve;

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ const path = require('path');
 
 const { RemoteBrowserTarget } = require('happo.io');
 
+const { findPagesDir } = require('next/dist/lib/find-pages-dir');
 const nextWebpackConfig = require('next/dist/build/webpack-config').default;
 const nextConfig = require('./next.config');
 
@@ -39,12 +40,16 @@ module.exports = {
       config: {
         devIndicators: {},
         distDir: happoTmpDir,
+        env: {},
         experimental: { plugins: [] },
         future: {},
-        env: {},
+        pageExtensions: [],
+        sassOptions: {},
         ...nextConfig,
       },
       entrypoints: {},
+      pagesDir: findPagesDir(process.cwd()),
+      rewrites: [],
     });
     config.plugins = base.plugins;
     config.resolve = base.resolve;


### PR DESCRIPTION
When following the example in this repo to [setup `happo` for `visx`](https://github.com/airbnb/visx/pull/1030/files#diff-cb69fee30d2d2e9d71756f4b08e12977751bf57f3f45072565501bbd8df64611R36) which is on `next@9.5.4`, I encountered several errors when running `yarn happo run` which seemed to come from an incomplete `nextWebpackConfig` config shape  (found a [similar issue](https://github.com/vercel/next.js/issues/21031) for `next-plugin-storybook` which extends the base `next` config; generally `next` says such usage of these internals isn't officially supported).

This PR updates the `.happo.js` + `README` to reflect the changes I made in case you'd like to update them here. Thanks!

@trotzig @lencioni